### PR TITLE
Update LangChain_Types_Explained.ipynb

### DIFF
--- a/LangChain_Types_Explained.ipynb
+++ b/LangChain_Types_Explained.ipynb
@@ -21,7 +21,8 @@
         "%pip install openai\n",
         "%pip install pinecone-client\n",
         "%pip install langchain\n",
-        "%pip install unstructured"
+        "%pip install unstructured\n"
+        "%pip install --upgrade pillow==8.0.0"
       ]
     },
     {


### PR DESCRIPTION
指定pillow版本解决from ._util import is_directory, is_path 报 cannot import name 'is_directory' 的问题